### PR TITLE
Add meetups

### DIFF
--- a/_meetups/2019-08-14.md
+++ b/_meetups/2019-08-14.md
@@ -1,6 +1,6 @@
 ---
 date: August 14, 2019
 ---
- * Special out of town guest Sarah Bird on browser tracking detection and protection</li>
+ * Special out of town guest Sarah Bird on browser tracking detection and protection
  * Fearless founder Bryan Van de Ven with [an intro to Bokeh](https://github.com/pydatapdx/meetups/blob/master/2019-08-14/PyData%20PDX%20Bokeh.pdf)
         

--- a/_meetups/2019-11-12.md
+++ b/_meetups/2019-11-12.md
@@ -1,5 +1,5 @@
 ---
 date: November 12, 2019
 ---
- * ['But the data was public anyway!' Practical ethics for the practicing data scientist"](https://github.com/pydatapdx/meetups/blob/master/2019-11-12/bedrick%20slides%20with%20presenter%20notes.pdf) by Steve Bedrick from OHSU
+ * ["'But the data was public anyway!' Practical ethics for the practicing data scientist"](https://github.com/pydatapdx/meetups/blob/master/2019-11-12/bedrick%20slides%20with%20presenter%20notes.pdf) by Steve Bedrick from OHSU
  * ["JupyterHub in Engineering Education"](https://github.com/pydatapdx/meetups/blob/master/2019-11-12/PeterKazarinoff_PyDataPDX_2019-11.pdf) by Peter Kazarinoff from Portland Community College

--- a/_meetups/2020-06-10.md
+++ b/_meetups/2020-06-10.md
@@ -4,4 +4,4 @@ date: June 10, 2020
 **The triumphant return, socially distanced**
 
  * ["Matchmaking for Industry: Estimating Expertise from Issue Tickets with Topic Modeling"](https://github.com/probinso/expert-modeling-system/blob/master/decks/pydatapdx/pres.pdf) by Philip Robinson, machine learning engineer
- * "A ridiculously brief introduction to Python, data, and GPUs" (lightening talk) by Adam Breindel
+ * "A ridiculously brief introduction to Python, data, and GPUs" (lightning talk) by Adam Breindel

--- a/_meetups/2020-07-08.md
+++ b/_meetups/2020-07-08.md
@@ -2,4 +2,4 @@
 date: July 8, 2020
 ---
  * "The Shape of a City: Applications of Urban Data Science in Housing and Land Use" by Marley Buchman
- * "Top 5 Troublesome Misconceptions about PySpark" (lightening talk) by Adam Breindel 
+ * "Top 5 Troublesome Misconceptions about PySpark" (lightning talk) by Adam Breindel 

--- a/_meetups/2021-01-13.md
+++ b/_meetups/2021-01-13.md
@@ -1,0 +1,5 @@
+---
+date: January 13, 2021
+---
+* ["The UX of Algorithm Transparency"](https://github.com/pydatapdx/meetups/blob/master/2021_01_13/The%20UX%20of%20Algorithmm%20Transparency%20-%20Kathryn%20Strauss.pdf) by Kathryn Strauss
+

--- a/_meetups/2021-02-10.md
+++ b/_meetups/2021-02-10.md
@@ -1,0 +1,6 @@
+---
+date: February 10, 2021
+---
+* ["Intro to Dask"](https://mybinder.org/v2/gh/adbreind/dask-micro-2021.git/HEAD?urlpath=lab) by Adam Breindel
+  * [Github repo](https://github.com/adbreind/dask-micro-2021)
+

--- a/_meetups/2021-03-10.md
+++ b/_meetups/2021-03-10.md
@@ -1,0 +1,9 @@
+---
+date: March 10, 2021
+---
+* ["Literate Programming with NBDev"](https://docs.google.com/presentation/d/11rYVbxvb77XdqPxoAoKN9Mw9Y4c_jVyYPeWFkvfvMoc/edit?usp=sharing) by Vishal Bakshi
+* ["Introduction to ML FLow"](https://mybinder.org/v2/gh/adbreind/pydata-pdx-mlflow.git/HEAD?urlpath=lab) by Adam Breindel
+  * [Github repo](https://github.com/adbreind/pydata-pdx-mlflow)
+* ["Seattle Police Accountability Data Tools"](https://docs.tech-bloc-sea.dev/slide/#/2/slide/view/ICpKOPrXSb6yrolbLzvA8WKCT03PNle9iU1Lrz4aJRs/present/) by Madison Swain-Bowden
+* ["Open Source Tools for Advanced Video Presentations"](https://github.com/pydatapdx/meetups/blob/master/2021_03_10/OpenSourceToolsForAdvancedVideoPresentations.md) by Allison Sliter
+* ["Wait Wait Stats and Data (Optimized)"](https://raw.githubusercontent.com/pydatapdx/meetups/master/2021_03_10/Wait%20Wait%20Stats%20and%20Data%20(Optimized).pdf) by Linh Pham

--- a/_meetups/2021-08-12.md
+++ b/_meetups/2021-08-12.md
@@ -1,0 +1,5 @@
+---
+date: August 12, 2021
+---
+* "Intro to R's Shiny" by Marley Buchman
+

--- a/_meetups/2021-09-08.md
+++ b/_meetups/2021-09-08.md
@@ -1,0 +1,5 @@
+---
+date: September 08, 2021
+---
+* ["Intro to Xarray"](https://github.com/raybellwaves/PyData-Portland-2021-talk) by Ray Bell
+

--- a/_meetups/2021-10-13.md
+++ b/_meetups/2021-10-13.md
@@ -1,0 +1,15 @@
+---
+date: October 13, 2021
+---
+Lightning Talks
+* "5 Tools Every Data Scientist Should Know About" by Madison Swain Bowden
+  * [Starship](https://starship.rs/)
+  * [GitKraken](https://gitkraken.com/)
+  * [GitHub CLI](https://cli.github.com/)
+  * [Github Codespaces GitHub.dev](https://github.com/features/codespaces)
+  * [Just](https://github.com/casey/just)
+* "Interactive Plots with Matplotlib" by Adam Breindel
+  * [How to Make Your Matplotlib Plots Interactive](https://levelup.gitconnected.com/how-to-make-your-matplotlib-plots-interactive-587f5a0db293)
+  * [Matplotlib Github](https://github.com/matplotlib/ipympl)
+* ["Top 5 Questions I Wish You'd Ask on a Job Interview"](https://www.canva.com/design/DAEsv8T-fIA/C4GLZhkVdvrPns_2qlYCRQ/view?utm_content=DAEsv8T-fIA&utm_campaign=designshare&utm_medium=link&utm_source=publishpresent#1) by Tiffany Dedeaux
+

--- a/_meetups/2021-11-10.md
+++ b/_meetups/2021-11-10.md
@@ -1,0 +1,5 @@
+---
+date: November 10, 2021
+---
+* ["Building a Modern Data Stack with dbt"](https://gist.github.com/jgdwyer/93282e10615af3dbdb2a28e59289a90a) by John Dwyer
+

--- a/_meetups/2021-12-08.md
+++ b/_meetups/2021-12-08.md
@@ -1,0 +1,5 @@
+---
+date: December 8, 2021
+---
+* "Why You Should be Using Pandas for Natural Language Processing" by Fred Ress
+

--- a/_meetups/2022-02-09.md
+++ b/_meetups/2022-02-09.md
@@ -1,0 +1,5 @@
+---
+date: February 09, 2022
+---
+* ["Online Machine Inference and Learning in Practice"](https://maxhalford.github.io/slides/online-ml-in-practice-pydata-pdx.pdf) by Max Halford, River core developer
+

--- a/_meetups/2022-03-09.md
+++ b/_meetups/2022-03-09.md
@@ -1,0 +1,5 @@
+---
+date: March 09, 2022
+---
+* ["PyTorch Lightning Intro"](https://github.com/adbreind/pydata-pdx-pytorchlightning) by Adam Breindel
+* "Community Shared Tasks: Automated Speech Recognitin After a Stroke" by Steven Bedrick

--- a/_meetups/2022-04-13.md
+++ b/_meetups/2022-04-13.md
@@ -1,0 +1,4 @@
+---
+date: April 13, 2022
+---
+* ["Machine Learning with PyCaret"](https://github.com/pycaret/pycaret-demo-pydata) by Moez Ali

--- a/_meetups/2022-05-15.md
+++ b/_meetups/2022-05-15.md
@@ -1,0 +1,4 @@
+---
+date: May 15, 2022
+---
+* PyData PDX picnic in Willamette Park

--- a/_meetups/2022-06-08.md
+++ b/_meetups/2022-06-08.md
@@ -1,0 +1,4 @@
+---
+date: June 08, 2022
+---
+* Data-driven Happy Hour @ Show Bar


### PR DESCRIPTION
Adding info for recent meetups.

Some months are missing completely, a few others only have partial info, but I believe the included meetups match the style of [pdx.pydata.org](https://pdx.pydata.org)